### PR TITLE
Fix Docker run command and default port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["python", "backend/app.py"]
+CMD ["python", "-m", "backend.app"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -122,4 +122,5 @@ def logout():
 
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0')
+    port = int(os.getenv('PORT', 57701))
+    app.run(debug=True, host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- set backend app default port to 57701
- run backend as a module in Dockerfile

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c943d8b70832da4187abcd6339c52