### PR TITLE
Add JSON export button and backend endpoint

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -41,3 +41,34 @@ function download(i){
   a.download = 'result_'+i+'.md';
   a.click();
 }
+
+function exportJSON(i){
+  let md = document.getElementById('md'+i).textContent;
+  fetch('/json', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({markdown: md})
+  })
+    .then(r => r.json())
+    .then(data => {
+      let txt = document.getElementById('json'+i);
+      txt.style.display = 'block';
+      txt.value = data.json;
+      document.getElementById('copyJson'+i).style.display = 'inline';
+      document.getElementById('downloadJson'+i).style.display = 'inline';
+    });
+}
+
+function copyJson(i){
+  let el = document.getElementById('json'+i);
+  navigator.clipboard.writeText(el.value);
+}
+
+function downloadJson(i){
+  let el = document.getElementById('json'+i);
+  let blob = new Blob([el.value], {type: 'application/json'});
+  let a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'result_'+i+'.json';
+  a.click();
+}

--- a/frontend/result.html
+++ b/frontend/result.html
@@ -12,6 +12,11 @@
     <pre id="md{{ loop.index }}">{{ r.output }}</pre>
     <button onclick="copy({{ loop.index }})">Copy Markdown</button>
     <button onclick="download({{ loop.index }})">Download Markdown</button>
+    <button onclick="exportJSON({{ loop.index }})">Export as JSON</button>
+    <br>
+    <textarea id="json{{ loop.index }}" rows="10" cols="80" readonly style="display:none"></textarea><br>
+    <button id="copyJson{{ loop.index }}" onclick="copyJson({{ loop.index }})" style="display:none">Copy JSON</button>
+    <button id="downloadJson{{ loop.index }}" onclick="downloadJson({{ loop.index }})" style="display:none">Download JSON</button>
     <form method="post" action="{{ url_for('retry', filename=r.filename) }}">
         <textarea name="prompt" rows="6" cols="80">{{ r.prompt }}</textarea><br>
         <button type="submit">Edit & Retry</button>


### PR DESCRIPTION
## Summary
- enable export of results as JSON
- add JSON prompt with schema and LLM call
- add backend endpoint to convert markdown to JSON
- render Export JSON UI controls and JS handlers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684cb98deedc832d8d27707b9f04b291