### PR TITLE
Add progress bar on AI calls

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,6 +1,9 @@
 let dropArea = document.getElementById('drop-area');
 let fileElem = document.getElementById('fileElem');
 let gallery = document.getElementById('gallery');
+let progressContainer = document.getElementById('progress-container');
+let progressBar = document.getElementById('progress-bar');
+let progressInterval;
 
 if (dropArea) {
   ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
@@ -10,6 +13,15 @@ if (dropArea) {
   fileElem.addEventListener('change', () => previewFiles(fileElem.files));
 }
 
+let form = document.getElementById('form');
+if (form) {
+  form.addEventListener('submit', startProgress);
+}
+
+document.querySelectorAll('.retry-form').forEach(f => {
+  f.addEventListener('submit', startProgress);
+});
+
 function preventDefaults (e) { e.preventDefault(); e.stopPropagation(); }
 
 function handleDrop(e) {
@@ -17,6 +29,29 @@ function handleDrop(e) {
   let files = dt.files;
   fileElem.files = files;
   previewFiles(files);
+}
+
+function startProgress() {
+  if (!progressContainer) return;
+  progressContainer.style.display = 'block';
+  progressBar.style.width = '0%';
+  let width = 0;
+  progressInterval = setInterval(() => {
+    if (width < 95) {
+      width += 1;
+      progressBar.style.width = width + '%';
+    }
+  }, 150);
+}
+
+function stopProgress() {
+  if (!progressContainer) return;
+  clearInterval(progressInterval);
+  progressBar.style.width = '100%';
+  setTimeout(() => {
+    progressContainer.style.display = 'none';
+    progressBar.style.width = '0%';
+  }, 300);
 }
 
 function previewFiles(files) {
@@ -44,6 +79,7 @@ function download(i){
 
 function exportJSON(i){
   let md = document.getElementById('md'+i).textContent;
+  startProgress();
   fetch('/json', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
@@ -56,6 +92,9 @@ function exportJSON(i){
       txt.value = data.json;
       document.getElementById('copyJson'+i).style.display = 'inline';
       document.getElementById('downloadJson'+i).style.display = 'inline';
+    })
+    .finally(() => {
+      stopProgress();
     });
 }
 

--- a/frontend/result.html
+++ b/frontend/result.html
@@ -6,6 +6,9 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+    <div id="progress-container" style="display:none">
+        <div id="progress-bar"></div>
+    </div>
     <a href="{{ url_for('upload') }}">Back</a>
     {% for r in results %}
     <h3>{{ r.filename }} - {{ r.job_id }}</h3>
@@ -17,7 +20,7 @@
     <textarea id="json{{ loop.index }}" rows="10" cols="80" readonly style="display:none"></textarea><br>
     <button id="copyJson{{ loop.index }}" onclick="copyJson({{ loop.index }})" style="display:none">Copy JSON</button>
     <button id="downloadJson{{ loop.index }}" onclick="downloadJson({{ loop.index }})" style="display:none">Download JSON</button>
-    <form method="post" action="{{ url_for('retry', filename=r.filename) }}">
+    <form method="post" class="retry-form" action="{{ url_for('retry', filename=r.filename) }}">
         <textarea name="prompt" rows="6" cols="80">{{ r.prompt }}</textarea><br>
         <button type="submit">Edit & Retry</button>
     </form>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -6,3 +6,6 @@ table { border-collapse:collapse; margin-bottom:20px; }
 th, td { border:1px solid #ccc; padding:4px 8px; }
 form.login { display:flex; flex-direction:column; align-items:center; background:#fff; padding:20px; border-radius:5px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
 body.login-page { display:flex; justify-content:center; align-items:center; height:100vh; background:#f2f2f2; }
+
+#progress-container { position:fixed; top:0; left:0; width:100%; height:4px; background:#eee; z-index:9999; }
+#progress-bar { width:0%; height:100%; background:#4caf50; transition:width 0.3s ease; }

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -8,6 +8,9 @@
 <body>
     <h2>Upload Images (Model: {{ model }})</h2>
     <a href="{{ url_for('logout') }}">Logout</a>
+    <div id="progress-container" style="display:none">
+        <div id="progress-bar"></div>
+    </div>
     <div id="drop-area">Drop images here</div>
     <form id="form" method="post" enctype="multipart/form-data">
         <input id="fileElem" type="file" name="files" accept="image/*" multiple style="display:none"/>


### PR DESCRIPTION
## Summary
- show a thin progress bar during AI calls
- add progress bar container to upload and result pages
- animate bar in frontend JS for uploads, retries, and export JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d1b838d8c832db5c60a18fd1e5926