### PR TITLE
Fix assorted runtime issues

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -2,7 +2,9 @@ import os
 import sqlite3
 import datetime
 
-DB_PATH = os.path.join(os.getenv('UPLOAD_FOLDER', 'data'), 'requests.db')
+from backend.utils import UPLOAD_FOLDER
+
+DB_PATH = os.path.join(UPLOAD_FOLDER, 'requests.db')
 
 
 def init_db():

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 import datetime
 import base64
 from werkzeug.utils import secure_filename
@@ -19,10 +20,12 @@ def allowed_file(filename: str) -> bool:
 
 
 def save_file(file):
+    """Save an uploaded file to ``UPLOAD_FOLDER`` with a unique name."""
     now = datetime.datetime.utcnow().strftime('%Y%m%d-%H%M%S')
     filename = secure_filename(file.filename)
     ext = filename.rsplit('.', 1)[1].lower()
-    new_name = f"{now}.{ext}"
+    unique = uuid.uuid4().hex[:6]
+    new_name = f"{now}-{unique}.{ext}"
     path = os.path.join(UPLOAD_FOLDER, new_name)
     file.save(path)
     return new_name, path
@@ -81,7 +84,8 @@ def call_openai(path: str, prompt: str, filename: str) -> str:
 
 
 def convert_markdown(md: str) -> str:
-    return markdown(md)
+    """Convert markdown text to HTML with table support."""
+    return markdown(md, extras=["tables"])
 
 
 JSON_PROMPT = """Please convert the tables below into a single JSON object that strictly follows this JSON Schema:

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -43,7 +43,6 @@ function preventDefaults (e) { e.preventDefault(); e.stopPropagation(); }
 function handleDrop(e) {
   let dt = e.dataTransfer;
   let files = dt.files;
-  fileElem.files = files;
   previewFiles(files);
 }
 
@@ -72,6 +71,9 @@ function stopProgress() {
 
 function previewFiles(files) {
   filesToUpload = [...files];
+  Array.from(gallery.querySelectorAll('img')).forEach(img => {
+    URL.revokeObjectURL(img.src);
+  });
   gallery.innerHTML = '';
   filesToUpload.forEach((file, idx) => {
     let div = document.createElement('div');
@@ -163,6 +165,7 @@ applyBtn && (applyBtn.onclick = () => {
     let newFile = new File([blob], oldFile.name, {type: oldFile.type});
     filesToUpload[currentIndex] = newFile;
     let previewImg = gallery.children[currentIndex].querySelector('img');
+    URL.revokeObjectURL(previewImg.src);
     previewImg.src = URL.createObjectURL(newFile);
     closeEditor();
   }, filesToUpload[currentIndex].type);


### PR DESCRIPTION
## Summary
- avoid filename collisions by appending a uuid
- enable table rendering when converting markdown
- use consistent upload path for the SQLite DB
- drop unsupported direct assignment to `input.files`
- release object URLs when previews are replaced

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684d35fe0c6c832db2b41e15ecae5686