### PR TITLE
Ensure JSON responses use proper formatting

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -217,6 +217,8 @@ def call_openai_json(tables: str) -> str:
         response = openai.chat.completions.create(
             model=MODEL,
             messages=[{"role": "user", "content": message}],
+            response_format={"type": "json_object"},
+            temperature=0,
         )
         return response.choices[0].message.content
     except openai.OpenAIError as e:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import sys, pathlib, json
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from unittest.mock import patch, MagicMock, ANY
+from backend.utils import call_openai_json, MODEL
+import os
+
+
+def test_call_openai_json_valid_json():
+    os.environ['OPENAI_API_KEY'] = 'test'
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock(message=MagicMock(content='{"foo": "bar"}'))]
+    with patch('backend.utils.openai.chat.completions.create', return_value=mock_resp) as mock_create:
+        result = call_openai_json('tables')
+        json_obj = json.loads(result)  # Should not raise
+        assert json_obj == {"foo": "bar"}
+        mock_create.assert_called_once_with(
+            model=MODEL,
+            messages=[{"role": "user", "content": ANY}],
+            response_format={"type": "json_object"},
+            temperature=0,
+        )


### PR DESCRIPTION
## Summary
- add explicit `response_format` and `temperature` to `call_openai_json`
- test `call_openai_json` parses returned JSON

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d455c6c0c832d95ded949f8e3244c