### PR TITLE
Add image preprocessing with Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 Flask-Limiter
 openai
 markdown2
+Pillow

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -25,3 +25,14 @@ def client():
 def test_login(client):
     rv = client.post('/', data={'password': 'API2025'}, follow_redirects=True)
     assert b'Upload Images' in rv.data
+
+
+def test_preprocess_image(tmp_path):
+    from backend.utils import preprocess_image
+    from PIL import Image
+
+    img_path = tmp_path / 'color.png'
+    Image.new('RGB', (10, 10), 'red').save(img_path)
+    preprocess_image(str(img_path))
+    processed = Image.open(img_path)
+    assert processed.mode == 'L'


### PR DESCRIPTION
## Summary
- add Pillow dependency
- convert uploaded images to grayscale with autocontrast
- run preprocessing before encoding for OpenAI
- unit test new preprocessing function

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d4572aac4832d9a8cbd47d73737d9