### PR TITLE
Fix JSON endpoint and image preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cp .env.example .env
 ```bash
 docker-compose up -d --build
 ```
-4. Visit `http://localhost:5000` and login with the password.
+4. Visit `http://localhost:57701` and login with the password.
 
 ## Structure
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -121,8 +121,8 @@ def retry(filename):
 @limiter.limit(f"{RATE_LIMIT_PER_HOUR}/hour")
 def to_json():
     if not session.get('logged_in'):
-        return redirect(url_for('login'))
-    data = request.get_json() or {}
+        return jsonify({'error': 'Unauthorized'}), 401
+    data = request.get_json(silent=True) or {}
     markdown_tables = data.get('markdown', '')
     try:
         json_text = call_openai_json(markdown_tables)

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -2,6 +2,7 @@ import os
 import uuid
 import datetime
 import base64
+import shutil
 from werkzeug.utils import secure_filename
 import openai
 from markdown2 import markdown
@@ -47,8 +48,15 @@ def save_file(file):
 
 
 def preprocess_image(path: str) -> None:
-    """Convert image to grayscale and apply autocontrast in-place."""
-    with Image.open(path) as img:
+    """Convert image to grayscale and apply autocontrast in-place.
+
+    The original image is preserved as ``<file>.orig`` so retries start
+    from the unmodified source.
+    """
+    orig_path = f"{path}.orig"
+    if not os.path.exists(orig_path):
+        shutil.copy(path, orig_path)
+    with Image.open(orig_path) as img:
         gray = ImageOps.grayscale(img)
         processed = ImageOps.autocontrast(gray)
         processed.save(path)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -36,3 +36,4 @@ def test_preprocess_image(tmp_path):
     preprocess_image(str(img_path))
     processed = Image.open(img_path)
     assert processed.mode == 'L'
+    assert (img_path.with_suffix(img_path.suffix + '.orig')).exists()


### PR DESCRIPTION
## Summary
- preserve original image on upload so retries don't degrade quality
- handle missing auth in `/json` endpoint correctly and be tolerant of invalid JSON bodies
- correct README port instructions
- test that preprocessing saves a backup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68507fd72d88832da9bec760a0a7483f