### PR TITLE
Fix missing server start and indentation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -115,7 +115,7 @@ def retry(filename):
         'job_id': job_id,
         'prompt': prompt,
     }
-return render_template('result.html', results=[result])
+    return render_template('result.html', results=[result])
 
 
 @app.route('/json', methods=['POST'])
@@ -140,3 +140,4 @@ def logout():
 
 if __name__ == '__main__':
     port = int(os.getenv('PORT', 57701))
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- fix indentation on retry route return
- start the Flask server when run directly

## Testing
- `pip install -r requirements.txt -q`
- `pip install -r requirements-dev.txt -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68508f01a84c832d8072654ff744a248