### PR TITLE
Implement JSON detection for task 5

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -24,6 +24,7 @@ from backend.utils import (
     generate_job_id,
     call_openai,
     call_openai_json,
+    markdown_looks_like_json,
     convert_markdown,
     UPLOAD_FOLDER,
     MODEL,
@@ -52,8 +53,11 @@ init_db()
 
 def vision_pipeline(image_path: str):
     prompt = generate_prompt()
-    output_text = call_openai(image_path, prompt, os.path.basename(image_path))
-    return prompt, output_text
+    md = call_openai(image_path, prompt, os.path.basename(image_path))
+    if markdown_looks_like_json(md):
+        return prompt, md
+    json_out = call_openai_json(md)
+    return prompt, json_out
 
 
 @app.route('/', methods=['GET', 'POST'])

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -4,6 +4,8 @@ import datetime
 import base64
 import shutil
 import sqlite3
+import json
+import re
 from werkzeug.utils import secure_filename
 import openai
 from markdown2 import markdown
@@ -16,6 +18,16 @@ MODEL = os.getenv('MODEL', 'o4-mini')
 
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 openai.api_key = os.getenv('OPENAI_API_KEY')
+
+SCHEMA_KEYS = {"arrival_tanks", "departure_tanks", "products", "time_log", "draft_readings"}
+
+
+def markdown_looks_like_json(md: str) -> bool:
+    try:
+        obj = json.loads(md)
+        return SCHEMA_KEYS <= obj.keys()
+    except json.JSONDecodeError:
+        return False
 
 # Database path shared across the app
 DB_PATH = os.path.join(UPLOAD_FOLDER, 'requests.db')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import sys, pathlib, json
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from unittest.mock import patch, MagicMock, ANY
-from backend.utils import call_openai_json, MODEL
+from backend.utils import call_openai_json, markdown_looks_like_json, MODEL
 import os
 
 
@@ -19,3 +19,10 @@ def test_call_openai_json_valid_json():
             response_format={"type": "json_object"},
             temperature=0,
         )
+
+
+def test_markdown_looks_like_json():
+    good = '{"arrival_tanks": [], "departure_tanks": [], "products": [], "time_log": [], "draft_readings": []}'
+    bad = 'not json'
+    assert markdown_looks_like_json(good)
+    assert not markdown_looks_like_json(bad)


### PR DESCRIPTION
## Summary
- check if markdown already resembles JSON
- skip JSON formatter call in vision pipeline when not needed
- cover JSON detection with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850a3a38cb8832dbbadd1668c664d00