### PR TITLE
Implement cleanup for old uploads

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -31,6 +31,7 @@ from backend.utils import (
     MAX_FILE_SIZE_MB,
 )
 from backend.models import init_db, log_request
+from backend.cleanup import purge_old_uploads
 from backend import worker
 
 LOGIN_PASSWORD = os.getenv('LOGIN_PASSWORD', 'API2025')
@@ -49,6 +50,7 @@ limiter = Limiter(
 limiter.init_app(app)
 
 init_db()
+purge_old_uploads()
 
 
 def vision_pipeline(image_path: str):

--- a/backend/cleanup.py
+++ b/backend/cleanup.py
@@ -1,0 +1,18 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from backend.utils import UPLOAD_FOLDER
+
+UPLOAD_DIR = Path(UPLOAD_FOLDER)
+
+
+def purge_old_uploads(days: int = 7) -> None:
+    """Delete files in ``UPLOAD_DIR`` older than ``days`` days."""
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    for p in UPLOAD_DIR.iterdir():
+        try:
+            if p.is_file() and p.stat().st_mtime < cutoff.timestamp():
+                p.unlink(missing_ok=True)
+        except FileNotFoundError:
+            # File might be removed between listing and deletion
+            pass

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,20 @@
+import sys, pathlib, os
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from datetime import datetime, timedelta
+import importlib
+
+
+def test_purge_old_uploads(tmp_path, monkeypatch):
+    old_file = tmp_path / 'old.txt'
+    new_file = tmp_path / 'new.txt'
+    old_file.write_text('x')
+    new_file.write_text('y')
+    old_time = (datetime.utcnow() - timedelta(days=8)).timestamp()
+    os.utime(old_file, (old_time, old_time))
+    monkeypatch.setenv('UPLOAD_FOLDER', str(tmp_path))
+    from backend import utils, cleanup
+    importlib.reload(utils)
+    importlib.reload(cleanup)
+    cleanup.purge_old_uploads(days=7)
+    assert not old_file.exists()
+    assert new_file.exists()


### PR DESCRIPTION
## Summary
- create `backend/cleanup.py` with `purge_old_uploads()`
- call cleanup on app startup
- test garbage collection of old files

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850a4dff4c8832d8bde4ea1c75f3de9