### PR TITLE
Add missing Flask-WTF and pin httpx

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -4,3 +4,7 @@ Pillow==10.2.0
 openai==1.24.0
 passlib==1.7.4
 redis==5.0.4
+Flask-WTF==1.2.2
+httpx==0.27.2
+python-dotenv==1.1.0
+markdown2==2.5.3


### PR DESCRIPTION
## Summary
- include Flask-WTF in locked requirements
- pin httpx to 0.27.2 and add other runtime dependencies

## Testing
- `pip install -q -r requirements.lock`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6850a6e1ee28832d8f665d68dbb5ff1f