### PR TITLE
Fix argon2 backend

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -8,3 +8,4 @@ Flask-WTF==1.2.2
 httpx==0.27.2
 python-dotenv==1.1.0
 markdown2==2.5.3
+argon2-cffi==23.1.0


### PR DESCRIPTION
## Summary
- add argon2-cffi to `requirements.lock` so passlib can hash passwords

## Testing
- `pip install -q -r requirements.lock`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6850b97e6ec4832d9a75b58842fa08ae