### PR TITLE
Handle temperature per model

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import sys, pathlib, json
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from unittest.mock import patch, MagicMock, ANY
 from backend.utils import call_openai_json, markdown_looks_like_json, MODEL
+import openai
 import os
 
 
@@ -17,8 +18,29 @@ def test_call_openai_json_valid_json():
             model=MODEL,
             messages=[{"role": "user", "content": ANY}],
             response_format={"type": "json_object"},
-            temperature=0,
         )
+
+
+def test_call_openai_json_retry_without_temperature():
+    os.environ['OPENAI_API_KEY'] = 'test'
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock(message=MagicMock(content='{"foo": "bar"}'))]
+    error = openai.BadRequestError(
+        message="bad",
+        response=MagicMock(status_code=400, headers={}, request=None),
+        body={"error": {"code": "unsupported_value", "param": "temperature"}},
+    )
+    with patch('backend.utils.MODEL', 'gpt-3.5'), patch(
+        'backend.utils.openai.chat.completions.create',
+        side_effect=[error, mock_resp],
+    ) as mock_create:
+        result = call_openai_json('tables')
+        assert json.loads(result) == {"foo": "bar"}
+        assert mock_create.call_count == 2
+        first_args = mock_create.call_args_list[0].kwargs
+        assert first_args['temperature'] == 1
+        second_args = mock_create.call_args_list[1].kwargs
+        assert 'temperature' not in second_args
 
 
 def test_markdown_looks_like_json():


### PR DESCRIPTION
## Summary
- remove temperature for models that do not support it (`o3`, `o3-mini`, `o4-mini`)
- default to temperature=1 otherwise with retry if the API rejects the parameter
- update unit tests for the new behaviour

## Testing
- `pip install -r requirements.lock`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6850fcaaf0dc832d91eec98aac5d1974