### PR TITLE
Add editable HTML table before JSON export

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -27,7 +27,6 @@ from backend.utils import (
     call_openai,
     call_openai_json,
     enhance_tank_conditions,
-    markdown_looks_like_json,
     convert_markdown,
     UPLOAD_FOLDER,
     MODEL,
@@ -64,12 +63,7 @@ purge_old_uploads()
 def vision_pipeline(image_path: str):
     prompt = generate_prompt()
     md = call_openai(image_path, prompt, os.path.basename(image_path))
-    if markdown_looks_like_json(md):
-        json_out = md
-    else:
-        json_out = call_openai_json(md)
-    enhanced = enhance_tank_conditions(json_out)
-    return prompt, enhanced
+    return prompt, md
 
 
 @app.route('/', methods=['GET', 'POST'])

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -200,7 +200,8 @@ function download(i){
 }
 
 function exportJSON(i){
-  let md = document.getElementById('md'+i).textContent;
+  let container = document.getElementById('table'+i);
+  let md = tablesToMarkdown(container);
   startProgress();
   fetch('/json', {
     method: 'POST',
@@ -233,3 +234,42 @@ function downloadJson(i){
   a.download = 'result_'+i+'.json';
   a.click();
 }
+
+function makeTableEditable(container){
+  container.querySelectorAll('table').forEach(table => {
+    table.classList.add('editable');
+    table.querySelectorAll('th, td').forEach(cell => {
+      let text = cell.textContent.trim();
+      cell.textContent = '';
+      let input = document.createElement('input');
+      input.type = 'text';
+      input.value = text;
+      cell.appendChild(input);
+    });
+  });
+}
+
+function tablesToMarkdown(container){
+  let parts = [];
+  container.querySelectorAll('table').forEach(table => {
+    let lines = [];
+    let rows = table.querySelectorAll('tr');
+    rows.forEach((row, idx) => {
+      let cells = row.querySelectorAll('th, td');
+      let values = Array.from(cells).map(c => {
+        let inp = c.querySelector('input');
+        return (inp ? inp.value : c.textContent.trim()).replace(/\|/g, '\\|');
+      });
+      lines.push('|' + values.join('|') + '|');
+      if(idx === 0){
+        lines.push('|' + values.map(()=>'---').join('|') + '|');
+      }
+    });
+    parts.push(lines.join('\n'));
+  });
+  return parts.join('\n\n');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-editable-table]').forEach(el => makeTableEditable(el));
+});

--- a/frontend/result.html
+++ b/frontend/result.html
@@ -25,7 +25,7 @@
         <textarea name="prompt" rows="6" cols="80">{{ r.prompt }}</textarea><br>
         <button type="submit">Edit & Retry</button>
     </form>
-    <div>{{ r.html | safe }}</div>
+    <div id="table{{ loop.index }}" data-editable-table>{{ r.html | safe }}</div>
     <hr>
     {% endfor %}
 <script src="{{ url_for('static', filename='main.js') }}"></script>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -4,6 +4,7 @@ body { font-family: Arial, sans-serif; margin:40px; }
 pre { background:#f2f2f2; padding:10px; }
 table { border-collapse:collapse; margin-bottom:20px; }
 th, td { border:1px solid #ccc; padding:4px 8px; }
+table.editable input { width:100%; border:none; padding:4px 8px; box-sizing:border-box; }
 form.login { display:flex; flex-direction:column; align-items:center; background:#fff; padding:20px; border-radius:5px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
 body.login-page { display:flex; justify-content:center; align-items:center; height:100vh; background:#f2f2f2; }
 


### PR DESCRIPTION
## Summary
- render AI markdown table as editable HTML
- convert editable tables back to markdown before JSON export
- style editable inputs
- split JSON conversion so it runs only after manual review

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685117aff8cc832d8ef7507a89f18190