### PR TITLE
Fix table editing & move retry button

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -239,10 +239,6 @@ function makeTableEditable(container){
   container.querySelectorAll('table').forEach(table => {
     table.classList.add('editable');
     table.querySelectorAll('th, td').forEach(cell => {
-function makeTableEditable(container){
-  container.querySelectorAll('table').forEach(table => {
-    table.classList.add('editable');
-    table.querySelectorAll('th, td').forEach(cell => {
       cell.contentEditable = 'true';
     });
   });

--- a/frontend/result.html
+++ b/frontend/result.html
@@ -21,12 +21,12 @@
     <textarea id="json{{ loop.index }}" rows="10" cols="80" readonly style="display:none"></textarea><br>
     <button id="copyJson{{ loop.index }}" onclick="copyJson({{ loop.index }})" style="display:none">Copy JSON</button>
     <button id="downloadJson{{ loop.index }}" onclick="downloadJson({{ loop.index }})" style="display:none">Download JSON</button>
+    <div id="table{{ loop.index }}" data-editable-table>{{ r.html | safe }}</div>
     <form method="post" class="retry-form" action="{{ url_for('retry', filename=r.filename) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <textarea name="prompt" rows="6" cols="80">{{ r.prompt }}</textarea><br>
         <button type="submit">Edit & Retry</button>
     </form>
-    <div id="table{{ loop.index }}" data-editable-table>{{ r.html | safe }}</div>
     <hr>
     {% endfor %}
 <script src="{{ url_for('static', filename='main.js') }}"></script>


### PR DESCRIPTION
## Summary
- ensure editable tables by removing stray duplicate function
- place the prompt retry form below each table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851ab73277c832da4a770b3314a7fad