### PR TITLE
Improve table editability

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker-compose up -d --build
 ## Usage
 1. Drag and drop or select one or more image files (png/jpg/webp ≤8MB).
 2. After processing, copy or download the markdown tables.
-3. Review the rendered tables below. They are editable so you can correct any values before exporting.
+3. Review the rendered tables below. Each table cell uses an input box so you can correct the values before exporting.
 4. If the output still needs tweaking, edit the prompt and hit **Edit & Retry**.
 
 ## Testing

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -236,10 +236,19 @@ function downloadJson(i){
 }
 
 function makeTableEditable(container){
-  container.querySelectorAll('table').forEach(table => {
+  container.querySelectorAll('table').forEach((table, tIdx) => {
     table.classList.add('editable');
-    table.querySelectorAll('th, td').forEach(cell => {
-      cell.contentEditable = 'true';
+    table.querySelectorAll('tr').forEach((row, rIdx) => {
+      row.querySelectorAll('th, td').forEach((cell, cIdx) => {
+        let text = cell.textContent.trim();
+        cell.textContent = '';
+        let input = document.createElement('input');
+        input.type = 'text';
+        input.value = text;
+        input.name = `t${tIdx}_r${rIdx}_c${cIdx}`;
+        input.id = `t${tIdx}_r${rIdx}_c${cIdx}`;
+        cell.appendChild(input);
+      });
     });
   });
 }
@@ -251,7 +260,10 @@ function tablesToMarkdown(container){
     let rows = table.querySelectorAll('tr');
     rows.forEach((row, idx) => {
       let cells = row.querySelectorAll('th, td');
-      let values = Array.from(cells).map(c => c.textContent.trim().replace(/\|/g, '\\|'));
+      let values = Array.from(cells).map(c => {
+        let inp = c.querySelector('input');
+        return (inp ? inp.value : c.textContent.trim()).replace(/\|/g, '\\|');
+      });
       lines.push('|' + values.join('|') + '|');
       if(idx === 0){
         lines.push('|' + values.map(()=>'---').join('|') + '|');

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -4,14 +4,13 @@ body { font-family: Arial, sans-serif; margin:40px; }
 pre { background:#f2f2f2; padding:10px; }
 table { border-collapse:collapse; margin-bottom:20px; }
 th, td { border:1px solid #ccc; padding:4px 8px; }
-table.editable td[contenteditable],
-table.editable th[contenteditable] {
-  min-width:40px;
-  border:1px solid #ccc;
+table.editable input {
+  width:100%;
+  border:none;
   padding:4px 8px;
+  box-sizing:border-box;
 }
-table.editable td[contenteditable]:focus,
-table.editable th[contenteditable]:focus {
+table.editable input:focus {
   outline:2px solid #4caf50;
 }
 .edit-note { font-style: italic; color: #555; margin: 5px 0; }


### PR DESCRIPTION
## Summary
- use `<input>` fields for editable tables
- adjust table markdown exporter to use input values
- tweak table styles for inputs
- clarify README usage note

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851af74be70832da813ed12411378c9