### PR TITLE
Add per-job history and admin editing

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -4,8 +4,9 @@ import datetime
 from backend.utils import UPLOAD_FOLDER, get_db, DB_PATH
 
 
-def init_db():
-    with get_db() as conn:
+def init_db(path: str = DB_PATH):
+    """Initialize a ``requests`` table in the SQLite database at ``path``."""
+    with get_db(path) as conn:
         conn.execute(
             """CREATE TABLE IF NOT EXISTS requests (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -18,8 +19,9 @@ def init_db():
         )
 
 
-def log_request(filename: str, ip: str, prompt: str, output: str):
-    with get_db() as conn:
+def log_request(filename: str, ip: str, prompt: str, output: str, db_path: str = DB_PATH):
+    """Insert a request row into the database at ``db_path``."""
+    with get_db(db_path) as conn:
         conn.execute(
             "INSERT INTO requests (filename, timestamp, ip, prompt, output) VALUES (?, ?, ?, ?, ?)",
             (filename, datetime.datetime.utcnow().isoformat(), ip, prompt, output),

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -35,8 +35,9 @@ def markdown_looks_like_json(md: str) -> bool:
 DB_PATH = os.path.join(UPLOAD_FOLDER, 'requests.db')
 
 
-def get_db():
-    conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+def get_db(path: str = DB_PATH):
+    """Return a SQLite connection to the given ``path``."""
+    conn = sqlite3.connect(path, check_same_thread=False)
     conn.execute('PRAGMA journal_mode=WAL;')
     return conn
 

--- a/frontend/history.html
+++ b/frontend/history.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Job History</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h2>Job History</h2>
+    <a href="{{ url_for('upload') }}">Back</a>
+    <table>
+        <tr><th>Job</th><th>Timestamp</th><th>Filename</th><th>IP</th></tr>
+        {% for job in jobs %}
+        <tr>
+            <td><a href="{{ url_for('job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a></td>
+            <td>{{ job.timestamp }}</td>
+            <td>{{ job.filename }}</td>
+            <td>{{ job.ip }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Edit Job {{ job_id }}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h2>Edit Job {{ job_id }}</h2>
+    <a href="{{ url_for('history') }}">Back</a>
+    <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        {% for r in rows %}
+        <h3>{{ r.filename }}</h3>
+        <label>Prompt:<br>
+            <textarea name="prompt_{{ r.id }}" rows="4" cols="80">{{ r.prompt }}</textarea>
+        </label><br>
+        <label>Output:<br>
+            <textarea name="output_{{ r.id }}" rows="10" cols="80">{{ r.output }}</textarea>
+        </label>
+        <hr>
+        {% endfor %}
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/frontend/result.html
+++ b/frontend/result.html
@@ -9,7 +9,8 @@
     <div id="progress-container" style="display:none">
         <div id="progress-bar"></div>
     </div>
-    <a href="{{ url_for('upload') }}">Back</a>
+    <a href="{{ url_for('upload') }}">Back</a> |
+    <a href="{{ url_for('history') }}">Admin</a>
     {% for r in results %}
     <h3>{{ r.filename }} - {{ r.job_id }}</h3>
     <pre id="md{{ loop.index }}">{{ r.output }}</pre>

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <h2>Upload Images (Model: {{ model }})</h2>
+    <a href="{{ url_for('history') }}">Admin</a> |
     <a href="{{ url_for('logout') }}">Logout</a>
     <div id="progress-container" style="display:none">
         <div id="progress-bar"></div>


### PR DESCRIPTION
## Summary
- store each upload session in its own database file
- add `/history` and `/job/<id>` admin pages
- show admin link on upload and result pages
- allow editing prompts and outputs for stored jobs

## Testing
- `pip install -r requirements.txt -q`
- `pip install -r requirements-dev.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851b1eca8f8832d8de95a160c4aadba