### PR TITLE
Add JSON generator for admin jobs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -110,7 +110,13 @@ def upload():
                     prompt, output_text = fut.result()
                 except Exception as e:
                     prompt, output_text = generate_prompt(), str(e)
-                log_request(new_name, request.remote_addr, prompt, output_text, db_path=job_path)
+                log_request(
+                    new_name,
+                    request.remote_addr,
+                    prompt,
+                    output_text,
+                    db_path=job_path,
+                )
                 html_output = convert_markdown(output_text)
                 results.append(
                     {
@@ -141,7 +147,13 @@ def retry(filename):
     job_id = generate_job_id()
     job_path = job_db_path(job_id)
     init_db(job_path)
-    log_request(filename, request.remote_addr, prompt, output_text, db_path=job_path)
+    log_request(
+        filename,
+        request.remote_addr,
+        prompt,
+        output_text,
+        db_path=job_path,
+    )
     html_output = convert_markdown(output_text)
     result = {
         'filename': filename,
@@ -196,15 +208,21 @@ def job_detail(job_id):
                 pid = r[0]
                 prompt_val = request.form.get(f'prompt_{pid}', '')
                 output_val = request.form.get(f'output_{pid}', '')
+                json_val = request.form.get(f'json_{pid}', '')
                 conn.execute(
-                    "UPDATE requests SET prompt=?, output=? WHERE id=?",
-                    (prompt_val, output_val, pid),
+                    "UPDATE requests SET prompt=?, output=?, json=? WHERE id=?",
+                    (
+                        prompt_val,
+                        output_val,
+                        json_val,
+                        pid,
+                    ),
                 )
         flash('Job updated')
         return redirect(url_for('job_detail', job_id=job_id))
     with get_db(db_path) as conn:
         rows = conn.execute(
-            "SELECT id, filename, prompt, output FROM requests ORDER BY id"
+            "SELECT id, filename, prompt, output, json FROM requests ORDER BY id"
         ).fetchall()
     rows = [
         {
@@ -212,6 +230,7 @@ def job_detail(job_id):
             'filename': r[1],
             'prompt': r[2],
             'output': r[3],
+            'json': r[4],
         }
         for r in rows
     ]

--- a/backend/models.py
+++ b/backend/models.py
@@ -14,15 +14,30 @@ def init_db(path: str = DB_PATH):
                 timestamp TEXT,
                 ip TEXT,
                 prompt TEXT,
-                output TEXT
+                output TEXT,
+                json TEXT
             )"""
         )
 
 
-def log_request(filename: str, ip: str, prompt: str, output: str, db_path: str = DB_PATH):
+def log_request(
+    filename: str,
+    ip: str,
+    prompt: str,
+    output: str,
+    db_path: str = DB_PATH,
+    json_text: str = "",
+):
     """Insert a request row into the database at ``db_path``."""
     with get_db(db_path) as conn:
         conn.execute(
-            "INSERT INTO requests (filename, timestamp, ip, prompt, output) VALUES (?, ?, ?, ?, ?)",
-            (filename, datetime.datetime.utcnow().isoformat(), ip, prompt, output),
+            "INSERT INTO requests (filename, timestamp, ip, prompt, output, json) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                filename,
+                datetime.datetime.utcnow().isoformat(),
+                ip,
+                prompt,
+                output,
+                json_text,
+            ),
         )

--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -6,8 +6,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+    <div id="progress-container" style="display:none">
+        <div id="progress-bar"></div>
+    </div>
     <h2>Edit Job {{ job_id }}</h2>
     <a href="{{ url_for('history') }}">Back</a>
+    <button type="button" onclick="adminGenerateAllJSON()">Generate JSON For All</button>
     <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         {% for r in rows %}
@@ -18,9 +22,15 @@
         <label>Output:<br>
             <textarea name="output_{{ r.id }}" rows="10" cols="80">{{ r.output }}</textarea>
         </label>
+        <br>
+        <label>JSON:<br>
+            <textarea name="json_{{ r.id }}" rows="10" cols="80">{{ r.json }}</textarea>
+        </label>
+        <button type="button" data-json-id="{{ r.id }}" onclick="adminGenerateJSON({{ r.id }})">Generate JSON</button>
         <hr>
         {% endfor %}
         <button type="submit">Save</button>
     </form>
+    <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -277,3 +277,28 @@ function tablesToMarkdown(container){
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('[data-editable-table]').forEach(el => makeTableEditable(el));
 });
+
+function adminGenerateJSON(id){
+  startProgress();
+  const md = document.querySelector(`textarea[name='output_${id}']`).value;
+  fetch('/json', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({markdown: md})
+  })
+    .then(r => r.json())
+    .then(data => {
+      const txt = document.querySelector(`textarea[name='json_${id}']`);
+      if (txt) txt.value = data.json;
+    })
+    .finally(() => {
+      stopProgress();
+    });
+}
+
+function adminGenerateAllJSON(){
+  document.querySelectorAll('[data-json-id]').forEach(btn => {
+    const id = btn.dataset.jsonId;
+    adminGenerateJSON(id);
+  });
+}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -40,3 +40,15 @@ def test_preprocess_image(tmp_path):
     processed = Image.open(img_path)
     assert processed.mode == 'L'
     assert (img_path.with_suffix(img_path.suffix + '.orig')).exists()
+
+
+def test_log_request_saves_json(tmp_path):
+    from backend.models import init_db, log_request
+    from backend.utils import get_db
+
+    db = tmp_path / 't.db'
+    init_db(str(db))
+    log_request('f', '1.1.1.1', 'p', 'o', db_path=str(db), json_text='{"a":1}')
+    with get_db(str(db)) as conn:
+        row = conn.execute('SELECT json FROM requests').fetchone()
+    assert row[0] == '{"a":1}'


### PR DESCRIPTION
## Summary
- allow JSON column in request logs
- record JSON in `log_request`
- expose JSON editing in admin panel and provide generation helpers
- add tests for new database column

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851b6cff5cc832dbcd25ec0f71eefe1