### PR TITLE
Fix job detail for missing database

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -201,6 +201,14 @@ def job_detail(job_id):
     if not session.get('logged_in'):
         return redirect(url_for('login'))
     db_path = job_db_path(job_id)
+    if not os.path.exists(db_path):
+        return (
+            render_template(
+                "error.html",
+                message="Job not found",
+            ),
+            404,
+        )
     if request.method == 'POST':
         with get_db(db_path) as conn:
             rows = conn.execute("SELECT id FROM requests").fetchall()

--- a/frontend/error.html
+++ b/frontend/error.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Error</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h2>{{ message }}</h2>
+    <a href="{{ url_for('history') }}">Back</a>
+</body>
+</html>

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -17,6 +17,7 @@ def client():
     os.environ['UPLOAD_FOLDER'] = db_dir
     app.config['TESTING'] = True
     app.config['WTF_CSRF_ENABLED'] = False
+    os.makedirs(db_dir, exist_ok=True)
     init_db()
     with app.test_client() as client:
         yield client
@@ -52,3 +53,10 @@ def test_log_request_saves_json(tmp_path):
     with get_db(str(db)) as conn:
         row = conn.execute('SELECT json FROM requests').fetchone()
     assert row[0] == '{"a":1}'
+
+
+def test_job_detail_missing_db(client):
+    client.post('/', data={'password': 'API2025'}, follow_redirects=True)
+    rv = client.get('/job/doesnotexist')
+    assert rv.status_code == 404
+    assert b'Job not found' in rv.data


### PR DESCRIPTION
## Summary
- avoid crash when `/job/<id>` database file is missing
- add simple error template
- test missing job returns 404

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851bd09ac88832db0d497e515dd245c