### PR TITLE
Fix legacy job detail DB schema

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -209,6 +209,11 @@ def job_detail(job_id):
             ),
             404,
         )
+    # Ensure database schema is up to date (older jobs may lack the ``json``
+    # column).  ``init_db`` will create the table if needed and add the column
+    # when missing.
+    init_db(db_path)
+
     if request.method == 'POST':
         with get_db(db_path) as conn:
             rows = conn.execute("SELECT id FROM requests").fetchall()


### PR DESCRIPTION
## Summary
- ensure models.init_db upgrades old schemas missing `json` column
- call init_db in job_detail route to apply upgrades
- test that old job databases are upgraded transparently

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851bf83a480832da65f6f161a88d488