### PR TITLE
Add job deletion from admin history

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -196,6 +196,20 @@ def history():
     return render_template('history.html', jobs=jobs)
 
 
+@app.route('/delete_job/<job_id>', methods=['POST'])
+def delete_job(job_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('login'))
+    db_path = job_db_path(job_id)
+    if os.path.exists(db_path):
+        try:
+            os.remove(db_path)
+        except OSError:
+            pass
+    flash('Job deleted')
+    return redirect(url_for('history'))
+
+
 @app.route('/job/<job_id>', methods=['GET', 'POST'])
 def job_detail(job_id):
     if not session.get('logged_in'):

--- a/frontend/history.html
+++ b/frontend/history.html
@@ -9,9 +9,15 @@
     <h2>Job History</h2>
     <a href="{{ url_for('upload') }}">Back</a>
     <table>
-        <tr><th>Job</th><th>Timestamp</th><th>Filename</th><th>IP</th></tr>
+        <tr><th></th><th>Job</th><th>Timestamp</th><th>Filename</th><th>IP</th></tr>
         {% for job in jobs %}
         <tr>
+            <td>
+                <form method="post" action="{{ url_for('delete_job', job_id=job.job_id) }}" style="display:inline">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                    <button type="submit" onclick="return confirm('Are you sure you want to delete this job?')">Delete</button>
+                </form>
+            </td>
             <td><a href="{{ url_for('job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a></td>
             <td>{{ job.timestamp }}</td>
             <td>{{ job.filename }}</td>

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -95,3 +95,17 @@ def test_job_detail_upgrades_schema(client, tmp_path):
     with sqlite3.connect(db_path) as conn_check:
         cols = [r[1] for r in conn_check.execute('PRAGMA table_info(requests)')]
     assert 'json' in cols
+
+
+def test_delete_job(client, tmp_path):
+    client.post('/', data={'password': 'API2025'}, follow_redirects=True)
+    from pathlib import Path
+    from backend.utils import UPLOAD_FOLDER
+    from backend.models import init_db
+
+    db_path = Path(UPLOAD_FOLDER) / 'del.db'
+    init_db(str(db_path))
+
+    rv = client.post(f'/delete_job/{db_path.stem}', follow_redirects=True)
+    assert rv.status_code == 200
+    assert not db_path.exists()


### PR DESCRIPTION
## Summary
- allow admins to delete a job database
- show Delete button on job history page
- test deleting a job database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851c11a303c832db2c7efe685094736