### PR TITLE
Add job name editing

### DIFF
--- a/frontend/history.html
+++ b/frontend/history.html
@@ -9,7 +9,7 @@
     <h2>Job History</h2>
     <a href="{{ url_for('upload') }}">Back</a>
     <table>
-        <tr><th></th><th>Job</th><th>Timestamp</th><th>Filename</th><th>IP</th></tr>
+        <tr><th></th><th>Job</th><th>Name</th><th>Timestamp</th><th>Filename</th><th>IP</th></tr>
         {% for job in jobs %}
         <tr>
             <td>
@@ -19,6 +19,7 @@
                 </form>
             </td>
             <td><a href="{{ url_for('job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a></td>
+            <td>{{ job.job_name }}</td>
             <td>{{ job.timestamp }}</td>
             <td>{{ job.filename }}</td>
             <td>{{ job.ip }}</td>

--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -14,6 +14,9 @@
     <button type="button" onclick="adminGenerateAllJSON()">Generate JSON For All</button>
     <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <label>Job Name:
+            <input type="text" name="job_name" value="{{ job_name }}">
+        </label>
         {% for r in rows %}
         <h3>{{ r.filename }}</h3>
         <label>Prompt:<br>


### PR DESCRIPTION
## Summary
- store a job name in each job database
- show the job name in the history table
- allow editing the job name from the job page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851c8bb2988832d86d88943b6c94c54