### PR TITLE
Improve Redis handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ cp .env.example .env
 ```
 If you are running the app without HTTPS (e.g., on localhost), set
 `SESSION_COOKIE_SECURE=False` in your `.env` file so the login session works.
+Redis is used to persist rate-limit state. Ensure `REDIS_URL` points to your
+Redis server (for Docker Compose this is typically `redis://redis:6379`). If no
+Redis server is reachable, the app falls back to an in-memory limiter.
 3. Build and run with Docker:
 ```bash
 docker-compose up -d --build

--- a/backend/app.py
+++ b/backend/app.py
@@ -12,6 +12,7 @@ from flask import (
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from redis import Redis
+from redis.exceptions import RedisError
 from flask_wtf import CSRFProtect
 from passlib.hash import argon2
 from dotenv import load_dotenv
@@ -41,6 +42,11 @@ from backend import worker
 PASS_HASH = argon2.hash(os.environ['APP_PASSWORD'])
 RATE_LIMIT_PER_HOUR = int(os.getenv('RATE_LIMIT_PER_HOUR', 50))
 REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379')
+if REDIS_URL.startswith(('redis://', 'rediss://', 'unix://')):
+    try:
+        Redis.from_url(REDIS_URL).ping()
+    except RedisError:
+        REDIS_URL = 'memory://'
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 FRONTEND_DIR = os.path.join(BASE_DIR, "..", "frontend")
 app = Flask(__name__, template_folder=FRONTEND_DIR, static_folder=FRONTEND_DIR)


### PR DESCRIPTION
## Summary
- handle unreachable Redis with an in-memory fallback
- document Redis setup in README

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68521fa5e464832d932619d31bb0f437