### PR TITLE
Fix history route for legacy db

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -195,6 +195,9 @@ def history():
     job_files = sorted(Path(UPLOAD_FOLDER).glob('*.db'), key=lambda p: p.stat().st_mtime, reverse=True)
     jobs = []
     for f in job_files:
+        # Older job databases may predate the ``jobmeta`` table. ``init_db``
+        # upgrades the schema in-place so querying ``jobmeta`` doesn't fail.
+        init_db(str(f))
         with get_db(str(f)) as conn:
             row = conn.execute(
                 "SELECT filename, timestamp, ip FROM requests ORDER BY id DESC LIMIT 1"


### PR DESCRIPTION
## Summary
- ensure `jobmeta` table exists when listing history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852211098cc832db3382d33b5f29e6d