### PR TITLE
Fix admin JSON generation

### DIFF
--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -4,11 +4,13 @@
     <meta charset="utf-8">
     <title>Edit Job {{ job_id }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
     <div id="progress-container" style="display:none">
         <div id="progress-bar"></div>
     </div>
+    <div id="status-message"></div>
     <h2>Edit Job {{ job_id }}</h2>
     <a href="{{ url_for('history') }}">Back</a>
     <button type="button" onclick="adminGenerateAllJSON()">Generate JSON For All</button>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -18,6 +18,25 @@ let rotateRightBtn = document.getElementById('rotateRight');
 let cropper;
 let currentIndex = null;
 
+function getCSRFToken(){
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  if(meta) return meta.getAttribute('content');
+  const inp = document.querySelector('input[name="csrf_token"]');
+  return inp ? inp.value : '';
+}
+
+function showStatus(message){
+  let el = document.getElementById('status-message');
+  if(!el){
+    el = document.createElement('div');
+    el.id = 'status-message';
+    document.body.prepend(el);
+  }
+  el.textContent = message;
+  el.style.display = 'block';
+  setTimeout(() => { el.style.display = 'none'; }, 3000);
+}
+
 if (dropArea) {
   ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
     dropArea.addEventListener(eventName, preventDefaults, false);
@@ -205,7 +224,10 @@ function exportJSON(i){
   startProgress();
   fetch('/json', {
     method: 'POST',
-    headers: {'Content-Type': 'application/json'},
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCSRFToken()
+    },
     body: JSON.stringify({markdown: md})
   })
     .then(r => r.json())
@@ -215,6 +237,7 @@ function exportJSON(i){
       txt.value = data.json;
       document.getElementById('copyJson'+i).style.display = 'inline';
       document.getElementById('downloadJson'+i).style.display = 'inline';
+      showStatus('JSON generated');
     })
     .finally(() => {
       stopProgress();
@@ -283,13 +306,17 @@ function adminGenerateJSON(id){
   const md = document.querySelector(`textarea[name='output_${id}']`).value;
   fetch('/json', {
     method: 'POST',
-    headers: {'Content-Type': 'application/json'},
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCSRFToken()
+    },
     body: JSON.stringify({markdown: md})
   })
     .then(r => r.json())
     .then(data => {
       const txt = document.querySelector(`textarea[name='json_${id}']`);
       if (txt) txt.value = data.json;
+      showStatus('JSON generated');
     })
     .finally(() => {
       stopProgress();

--- a/frontend/result.html
+++ b/frontend/result.html
@@ -4,11 +4,13 @@
     <meta charset="utf-8">
     <title>Results</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
     <div id="progress-container" style="display:none">
         <div id="progress-bar"></div>
     </div>
+    <div id="status-message"></div>
     <a href="{{ url_for('upload') }}">Back</a> |
     <a href="{{ url_for('history') }}">Admin</a>
     {% for r in results %}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -26,3 +26,12 @@ body.login-page { display:flex; justify-content:center; align-items:center; heig
 
 #progress-container { position:fixed; top:0; left:0; width:100%; height:4px; background:#eee; z-index:9999; }
 #progress-bar { width:0%; height:100%; background:#4caf50; transition:width 0.3s ease; }
+
+#status-message {
+  background:#ddf0d8;
+  border:1px solid #a6d3a0;
+  color:#333;
+  padding:8px 12px;
+  margin-bottom:10px;
+  display:none;
+}


### PR DESCRIPTION
## Summary
- add CSRF token meta tags to pages using JSON generation
- show transient status messages after JSON is generated
- add helper to send CSRF header in fetch requests
- include basic styling for the status message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685257651af0832d872d237a6ef2c1c1