### PR TITLE
Optimize preview rendering with DocumentFragment

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -105,6 +105,7 @@ function previewFiles(files) {
     URL.revokeObjectURL(img.src);
   });
   gallery.innerHTML = '';
+  const frag = document.createDocumentFragment();
   filesToUpload.forEach((file, idx) => {
     let div = document.createElement('div');
     div.className = 'preview';
@@ -116,8 +117,9 @@ function previewFiles(files) {
     btn.addEventListener('click', () => openEditor(idx));
     div.appendChild(img);
     div.appendChild(btn);
-    gallery.appendChild(div);
+    frag.appendChild(div);
   });
+  gallery.appendChild(frag);
 }
 
 function openEditor(idx){


### PR DESCRIPTION
## Summary
- reduce DOM reflow when generating previews
- create a `DocumentFragment` in `previewFiles()` and append all preview nodes once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68526c0c8d34832daed4070dec9746a8