### PR TITLE
Defer cropperjs loading

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -17,6 +17,24 @@ let rotateLeftBtn = document.getElementById('rotateLeft');
 let rotateRightBtn = document.getElementById('rotateRight');
 let cropper;
 let currentIndex = null;
+let cropperReady;
+
+function loadCropper(){
+  if(!cropperReady){
+    cropperReady = new Promise((resolve, reject) => {
+      const css = document.createElement('link');
+      css.rel = 'stylesheet';
+      css.href = 'https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.css';
+      document.head.appendChild(css);
+      const script = document.createElement('script');
+      script.src = 'https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.js';
+      script.onload = () => resolve();
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+  }
+  return cropperReady;
+}
 
 function getCSRFToken(){
   const meta = document.querySelector('meta[name="csrf-token"]');
@@ -122,7 +140,8 @@ function previewFiles(files) {
   gallery.appendChild(frag);
 }
 
-function openEditor(idx){
+async function openEditor(idx){
+  await loadCropper();
   currentIndex = idx;
   let file = filesToUpload[idx];
   let reader = new FileReader();

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <title>Upload</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.css">
 </head>
 <body>
     <h2>Upload Images (Model: {{ model }})</h2>
@@ -39,7 +38,6 @@
     {% with messages = get_flashed_messages() %}
       {% if messages %}<div>{{ messages[0] }}</div>{% endif %}
     {% endwith %}
-<script src="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.js"></script>
 <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- defer CropperJS CSS/JS loading until the editor is opened
- remove the static `<link>`/`<script>` from the upload page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68526d573c64832dae7f6315982dee08