### PR TITLE
Improve image preprocessing concurrency

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -50,15 +50,26 @@ if (form) {
   form.addEventListener('submit', async e => {
     e.preventDefault();
     startProgress();
-    let dt = new DataTransfer();
-    for (let file of filesToUpload) {
-      const img = await createImageBitmap(file);
-      const canvas = new OffscreenCanvas(Math.min(img.width, 1024), Math.min(img.height, 1024));
-      const ctx = canvas.getContext('2d');
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-      const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.8 });
-      dt.items.add(new File([blob], file.name, { type: 'image/jpeg' }));
-    }
+    const dt = new DataTransfer();
+
+    const processed = await Promise.all(
+      filesToUpload.map(async file => {
+        const img = await createImageBitmap(file);
+        const canvas = new OffscreenCanvas(
+          Math.min(img.width, 1024),
+          Math.min(img.height, 1024)
+        );
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        const blob = await canvas.convertToBlob({
+          type: 'image/jpeg',
+          quality: 0.8
+        });
+        return new File([blob], file.name, { type: 'image/jpeg' });
+      })
+    );
+
+    processed.forEach(f => dt.items.add(f));
     fileElem.files = dt.files;
     form.submit();
   });


### PR DESCRIPTION
## Summary
- use `Promise.all` to process upload images concurrently in `main.js`

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68526d40c8e4832da0fdd9a9bc8c383d