### PR TITLE
Sanitize rendered markdown

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -11,6 +11,7 @@ import math
 from werkzeug.utils import secure_filename
 import openai
 from markdown2 import markdown
+import bleach
 from PIL import Image, ImageOps
 
 UPLOAD_FOLDER = os.getenv('UPLOAD_FOLDER', os.path.join('backend', 'data'))
@@ -164,8 +165,27 @@ def call_openai(path: str, prompt: str, filename: str) -> str:
 
 
 def convert_markdown(md: str) -> str:
-    """Convert markdown text to HTML with table support."""
-    return markdown(md, extras=["tables"])
+    """Convert markdown text to sanitized HTML with table support."""
+    html = markdown(md, extras=["tables"])
+    allowed_tags = set(bleach.sanitizer.ALLOWED_TAGS).union(
+        {
+            "p",
+            "br",
+            "pre",
+            "code",
+            "table",
+            "thead",
+            "tbody",
+            "tr",
+            "th",
+            "td",
+        }
+    )
+    return bleach.clean(
+        html,
+        tags=allowed_tags,
+        attributes=bleach.sanitizer.ALLOWED_ATTRIBUTES,
+    )
 
 
 JSON_PROMPT = """Please convert the tables below into a single JSON object that strictly follows this JSON Schema:

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,3 +9,4 @@ httpx==0.27.2
 python-dotenv==1.1.0
 markdown2==2.5.3
 argon2-cffi==23.1.0
+bleach==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ redis
 Flask-WTF
 passlib
 argon2-cffi
+bleach

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from backend.utils import (
     call_openai_json,
     markdown_looks_like_json,
     enhance_tank_conditions,
+    convert_markdown,
     MODEL,
 )
 import openai
@@ -89,4 +90,11 @@ def test_enhance_tank_conditions():
     assert tank["alpha"] == pytest.approx(0.0003744427624)
     assert tank["exp"] == pytest.approx(math.e)
     assert tank["VCF"] == pytest.approx(0.99625139939)
+
+
+def test_convert_markdown_sanitizes_script():
+    md = "Bad<script>alert('x')</script>\n\n|A|B|\n|--|--|\n|1|2|"
+    html = convert_markdown(md)
+    assert "<script>" not in html
+    assert "<table>" in html
 


### PR DESCRIPTION
## Summary
- sanitize markdown output with Bleach
- pin bleach dependency
- guard against script tags in markdown conversion
- test convert_markdown sanitization

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68526f199afc832d833c76afd97580c7