### PR TITLE
Add rate limit to login and test enforcement

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -83,6 +83,7 @@ def vision_pipeline(image_path: str):
 
 
 @app.route('/', methods=['GET', 'POST'])
+@limiter.limit(f"{RATE_LIMIT_PER_HOUR}/hour")
 def login():
     if request.method == 'POST':
         submitted_pw = request.form.get('password', '')

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -109,3 +109,13 @@ def test_delete_job(client, tmp_path):
     rv = client.post(f'/delete_job/{db_path.stem}', follow_redirects=True)
     assert rv.status_code == 200
     assert not db_path.exists()
+
+
+def test_login_rate_limit(client):
+    from backend.app import limiter, RATE_LIMIT_PER_HOUR
+    limiter.reset()
+    for _ in range(RATE_LIMIT_PER_HOUR):
+        rv = client.post('/', data={'password': 'wrong'})
+        assert rv.status_code == 200
+    rv = client.post('/', data={'password': 'wrong'})
+    assert rv.status_code == 429


### PR DESCRIPTION
## Summary
- apply limiter to the login route
- test that excessive login attempts return HTTP 429

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68526f1de1d0832d9d9c7cd97108bf48