### PR TITLE
Fix JSON editor initialization on pages without image controls

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -174,9 +174,11 @@ function closeEditor(){
   if(cropper){ cropper.destroy(); cropper = null; }
 }
 
-zoomRange.oninput = () => {
-  if(cropper) cropper.zoomTo(parseFloat(zoomRange.value));
-};
+if(zoomRange){
+  zoomRange.oninput = () => {
+    if(cropper) cropper.zoomTo(parseFloat(zoomRange.value));
+  };
+}
 
 let filterFrame;
 function updateFilters(){
@@ -185,8 +187,12 @@ function updateFilters(){
     editorImg.style.filter = `brightness(${brightnessRange.value}) contrast(${contrastRange.value})`;
   });
 }
-brightnessRange.oninput = updateFilters;
-contrastRange.oninput = updateFilters;
+if(brightnessRange){
+  brightnessRange.oninput = updateFilters;
+}
+if(contrastRange){
+  contrastRange.oninput = updateFilters;
+}
 rotateLeftBtn && (rotateLeftBtn.onclick = () => { if(cropper) cropper.rotate(-90); });
 rotateRightBtn && (rotateRightBtn.onclick = () => { if(cropper) cropper.rotate(90); });
 


### PR DESCRIPTION
## Summary
- avoid assigning event handlers when image editor controls don't exist
- keeps JavaScript running so JSON editor is usable on job detail pages

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685337fbe7f4832d91bfb3a1fac3b7eb