### PR TITLE
Improve JSON validation

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -31,9 +31,11 @@ SCHEMA_KEYS = {"arrival_tanks", "departure_tanks", "products", "time_log", "draf
 def markdown_looks_like_json(md: str) -> bool:
     try:
         obj = json.loads(md)
-        return SCHEMA_KEYS <= obj.keys()
     except json.JSONDecodeError:
         return False
+    if not isinstance(obj, dict):
+        return False
+    return SCHEMA_KEYS <= obj.keys()
 
 # Database path shared across the app
 DB_PATH = os.path.join(UPLOAD_FOLDER, 'requests.db')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,11 @@ def test_markdown_looks_like_json():
     assert not markdown_looks_like_json(bad)
 
 
+def test_markdown_looks_like_json_non_object():
+    arr = '[1, 2, 3]'
+    assert not markdown_looks_like_json(arr)
+
+
 def test_enhance_tank_conditions():
     data = {
         "tankConditions": {


### PR DESCRIPTION
## Summary
- avoid AttributeError in `markdown_looks_like_json` by verifying that the parsed data is a dict
- add regression test for JSON inputs that aren't objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6853556d23d8832d8d13e50a0792aeec