### PR TITLE
Add model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple web app for uploading field document images and extracting arrival and 
 - Password-protected login (`API2025` by default)
 - Drag & drop multi-upload with previews
 - Images stored with UTC timestamp names
-- Calls OpenAI Vision API (`o4-mini` by default)
+- Calls OpenAI Vision API (`o4-mini` by default, selectable on the upload page)
 - Shows markdown and rendered table output
 - Copy or download markdown results
 - Edit the prompt and retry extraction
@@ -59,9 +59,10 @@ docker-compose up -d --build
 
 ## Usage
 1. Drag and drop or select one or more image files (png/jpg/webp ≤8MB).
-2. After processing, copy or download the markdown tables.
-3. Review the rendered tables below. Each table cell uses an input box so you can correct the values before exporting.
-4. If the output still needs tweaking, edit the prompt and hit **Edit & Retry**.
+2. Choose the OpenAI model to use for extraction.
+3. After processing, copy or download the markdown tables.
+4. Review the rendered tables below. Each table cell uses an input box so you can correct the values before exporting.
+5. If the output still needs tweaking, edit the prompt and hit **Edit & Retry**.
 
 ## Testing
 Install dependencies and run pytest:

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -125,7 +125,9 @@ def generate_prompt() -> str:
     )
 
 
-def call_openai(path: str, prompt: str, filename: str) -> str:
+def call_openai(path: str, prompt: str, filename: str, model: str | None = None) -> str:
+    if model is None:
+        model = MODEL
     try:
         preprocess_image(path)
         with Image.open(path) as img:
@@ -135,7 +137,7 @@ def call_openai(path: str, prompt: str, filename: str) -> str:
             b64 = base64.b64encode(buf.getbuffer()).decode()
 
         params = {
-            "model": MODEL,
+            "model": model,
             "messages": [
                 {
                     "role": "user",
@@ -149,7 +151,7 @@ def call_openai(path: str, prompt: str, filename: str) -> str:
                 }
             ],
         }
-        if MODEL not in {"o3", "o3-mini", "o4-mini"}:
+        if model not in {"o3", "o3-mini", "o4-mini"}:
             params["temperature"] = 1
 
         try:
@@ -299,7 +301,9 @@ JSON_PROMPT = """Please convert the tables below into a single JSON object that 
 Output only valid JSON."""
 
 
-def call_openai_json(tables: str) -> str:
+def call_openai_json(tables: str, model: str | None = None) -> str:
+    if model is None:
+        model = MODEL
     """Convert extracted tables to JSON via a second model call.
 
     High-reasoning models such as ``o3`` and ``o4-mini`` ignore custom
@@ -310,11 +314,11 @@ def call_openai_json(tables: str) -> str:
 
     message = tables + "\n\n" + JSON_PROMPT
     params = {
-        "model": MODEL,
+        "model": model,
         "messages": [{"role": "user", "content": message}],
         "response_format": {"type": "json_object"},
     }
-    if MODEL not in {"o3", "o3-mini", "o4-mini"}:
+    if model not in {"o3", "o3-mini", "o4-mini"}:
         params["temperature"] = 1
 
     try:

--- a/frontend/result.html
+++ b/frontend/result.html
@@ -28,6 +28,7 @@
     <div id="table{{ loop.index }}" data-editable-table>{{ r.html | safe }}</div>
     <form method="post" class="retry-form" action="{{ url_for('retry', filename=r.filename) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="hidden" name="model" value="{{ model }}" />
         <textarea name="prompt" rows="6" cols="80">{{ r.prompt }}</textarea><br>
         <button type="submit">Edit & Retry</button>
     </form>

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -15,6 +15,9 @@
     <div id="drop-area">Drop images here</div>
     <form id="form" method="post" enctype="multipart/form-data">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <label>Model:
+            <input type="text" name="model" value="{{ model }}" />
+        </label><br>
         <input id="fileElem" type="file" name="files" accept="image/*" multiple style="display:none"/>
         <button type="button" onclick="document.getElementById('fileElem').click()">Select Files</button>
         <div id="gallery"></div>


### PR DESCRIPTION
## Summary
- allow specifying a model on the upload page
- persist the chosen model in the session
- pass selected model to OpenAI calls
- document model selection in the README

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68535896d72c832da4faad6f1f48ea70