### PR TITLE
Add job attachments

### DIFF
--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -15,6 +15,19 @@
     <h2>Edit Job {{ job_id }}</h2>
     <a href="{{ url_for('history') }}">Back</a>
     <button type="button" onclick="adminGenerateAllJSON()">Generate JSON For All</button>
+    <h3>Attachments</h3>
+    <ul>
+        {% for a in attachments %}
+        <li><a href="{{ url_for('uploaded_file', filename=a.filename) }}">{{ a.filename }}</a> - {{ a.timestamp }}</li>
+        {% else %}
+        <li>No attachments</li>
+        {% endfor %}
+    </ul>
+    <form method="post" enctype="multipart/form-data">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="file" name="attachment" required>
+        <button type="submit">Upload</button>
+    </form>
     <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <label>Job Name:


### PR DESCRIPTION
## Summary
- allow each job to store extra uploaded documents
- expose attachments table and helper functions
- handle attachment upload on the job detail page
- add route to download uploaded files
- list and upload attachments in the job detail template
- test attachment table creation and upload

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6854927fc90c832db743cc0a07bf8730