### PR TITLE
Add BDR extraction route with autosave

### DIFF
--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -46,6 +46,7 @@
             <textarea name="json_{{ r.id }}" rows="10" cols="80">{{ r.json }}</textarea>
         </label>
         <button type="button" data-json-id="{{ r.id }}" onclick="adminGenerateJSON({{ r.id }})">Generate JSON</button>
+        <button type="button" onclick="extractBDR({{ r.id }})">Extract BDR</button>
         <button type="button" onclick="prettyPrintTextarea('json_{{ r.id }}')">Pretty Print JSON</button>
         <button type="button" onclick="openJSONEditor({{ r.id }})">Edit JSON</button>
         <hr>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -384,6 +384,30 @@ function adminGenerateJSON(id){
     });
 }
 
+function extractBDR(id){
+  startProgress();
+  const jobId = document.body.dataset.jobId;
+  fetch(`/extract_bdr/${jobId}/${id}`, {
+    method: 'POST',
+    headers: {
+      'X-CSRFToken': getCSRFToken()
+    }
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (data.error){
+        alert(data.error);
+        return;
+      }
+      const txt = document.querySelector(`textarea[name='json_${id}']`);
+      if (txt) txt.value = data.json;
+      showStatus('BDR data extracted');
+    })
+    .finally(() => {
+      stopProgress();
+    });
+}
+
 function prettyPrintTextarea(name){
   const txt = document.querySelector(`textarea[name='${name}']`);
   if(!txt) return;


### PR DESCRIPTION
## Summary
- add `BDR_PROMPT` and `merge_bdr_json` helper in extraction module
- implement `/extract_bdr/<job_id>/<req_id>` endpoint
- update job detail page with **Extract BDR** button
- provide JS helper to call the endpoint

## Testing
- `pip install -r requirements.txt -q`
- `pip install -r requirements-dev.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854995665fc832d895c5e274758a88f