### PR TITLE
Simplify BDR extraction logic

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -367,7 +367,7 @@ def extract_bdr_route(job_id, req_id):
     model = session.get('model', MODEL)
     image_path = os.path.join(UPLOAD_FOLDER, filename)
     try:
-        output_text = call_openai(image_path, BDR_PROMPT, filename, model)
+        output_text = call_openai(image_path, BDR_PROMPT, filename, model, crop_top_fraction=0.33)
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -125,12 +125,21 @@ def generate_prompt() -> str:
     )
 
 
-def call_openai(path: str, prompt: str, filename: str, model: str | None = None) -> str:
+def call_openai(
+    path: str,
+    prompt: str,
+    filename: str,
+    model: str | None = None,
+    crop_top_fraction: float | None = None,
+) -> str:
     if model is None:
         model = MODEL
     try:
         preprocess_image(path)
         with Image.open(path) as img:
+            if crop_top_fraction:
+                crop_height = int(img.height * crop_top_fraction)
+                img = img.crop((0, 0, img.width, crop_height))
             buf = io.BytesIO()
             img.save(buf, format="PNG")
             ext = "png"

--- a/tests/test_bdr.py
+++ b/tests/test_bdr.py
@@ -17,18 +17,12 @@ def test_extract_bdr_sample():
     )
     result = extract_bdr(text)
     assert result["vessel_name"] == "MATSON ANCHORAGE"
-    assert result["barge_name"] == "CENTERLINE LOGISTICS CORP. / SHAUNA KAY"
-    assert result["vessel_flag"] == "U.S."
-    assert result["port_delivery_location"] == "TACOMA, WA"
-    assert result["date"] == "2025-06-18"
+    assert result["delivery_location"] == "TACOMA, WA"
     assert len(result["products"]) == 1
     prod = result["products"][0]
     assert math.isclose(prod["delivery_temperature_f"], 113.0, abs_tol=0.1)
     assert math.isclose(prod["flash_point_f"], 179.6, abs_tol=0.1)
     assert math.isclose(prod["pour_point_f"], 15.8, abs_tol=0.1)
-    seals = {(d["product"], d["sample_type"], d["seal_number"]) for d in result["sample_seal_numbers"]}
-    assert ("IFO 380", "Marpol", "1120971") in seals
-    assert ("IFO 380", "Barge", "1120974") in seals
 
 
 def test_extract_bdr_variant_headers():
@@ -48,6 +42,4 @@ def test_extract_bdr_variant_headers():
     assert prod["product_name"] == "MGO"
     assert prod["weight_mt"] == 100
     assert math.isclose(prod["delivery_temperature_f"], 100, abs_tol=0.1)
-    seals = {(d["sample_type"], d["seal_number"]) for d in result["sample_seal_numbers"]}
-    assert ("Marpol Sample", "A1") in seals
-    assert ("Barge", "D4") in seals
+


### PR DESCRIPTION
## Summary
- create a simplified `BDR_PROMPT` and remove sample seal extraction
- crop the top third of BDR images before sending to OpenAI
- strip unused BDR fields and update utilities
- adjust tests to new schema

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854d36e74dc832da5bad7c3bcbcc8d8