### PR TITLE
Separate BDR JSON output

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -19,7 +19,8 @@ def init_db(path: str = DB_PATH):
                 ip TEXT,
                 prompt TEXT,
                 output TEXT,
-                json TEXT
+                json TEXT,
+                bdr_json TEXT
             )"""
         )
         # Upgrade schema if ``json`` column is missing (for databases created
@@ -27,6 +28,8 @@ def init_db(path: str = DB_PATH):
         cols = [row[1] for row in conn.execute("PRAGMA table_info(requests)")]
         if "json" not in cols:
             conn.execute("ALTER TABLE requests ADD COLUMN json TEXT")
+        if "bdr_json" not in cols:
+            conn.execute("ALTER TABLE requests ADD COLUMN bdr_json TEXT")
         # Table for storing per-job metadata such as the job name
         conn.execute(
             "CREATE TABLE IF NOT EXISTS jobmeta (name TEXT)"
@@ -51,11 +54,12 @@ def log_request(
     output: str,
     db_path: str = DB_PATH,
     json_text: str = "",
+    bdr_json_text: str = "",
 ):
     """Insert a request row into the database at ``db_path``."""
     with get_db(db_path) as conn:
         conn.execute(
-            "INSERT INTO requests (filename, timestamp, ip, prompt, output, json) VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO requests (filename, timestamp, ip, prompt, output, json, bdr_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 filename,
                 datetime.datetime.utcnow().isoformat(),
@@ -63,6 +67,7 @@ def log_request(
                 prompt,
                 output,
                 json_text,
+                bdr_json_text,
             ),
         )
 

--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -45,9 +45,13 @@
         <label>JSON:<br>
             <textarea name="json_{{ r.id }}" rows="10" cols="80">{{ r.json }}</textarea>
         </label>
+        <label>BDR JSON:<br>
+            <textarea name="bdr_json_{{ r.id }}" rows="10" cols="80">{{ r.bdr_json }}</textarea>
+        </label>
         <button type="button" data-json-id="{{ r.id }}" onclick="adminGenerateJSON({{ r.id }})">Generate JSON</button>
         <button type="button" onclick="extractBDR({{ r.id }})">Extract BDR</button>
         <button type="button" onclick="prettyPrintTextarea('json_{{ r.id }}')">Pretty Print JSON</button>
+        <button type="button" onclick="prettyPrintTextarea('bdr_json_{{ r.id }}')">Pretty Print BDR JSON</button>
         <button type="button" onclick="openJSONEditor({{ r.id }})">Edit JSON</button>
         <hr>
         {% endfor %}

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -399,8 +399,8 @@ function extractBDR(id){
         alert(data.error);
         return;
       }
-      const txt = document.querySelector(`textarea[name='json_${id}']`);
-      if (txt) txt.value = data.json;
+      const txt = document.querySelector(`textarea[name='bdr_json_${id}']`);
+      if (txt) txt.value = data.bdr_json;
       showStatus('BDR data extracted');
     })
     .finally(() => {

--- a/frontend/result.html
+++ b/frontend/result.html
@@ -22,6 +22,7 @@
     <p class="edit-note">Edit the table below before exporting.</p>
     <br>
     <textarea id="json{{ loop.index }}" rows="10" cols="80" readonly style="display:none"></textarea><br>
+    <textarea id="bdrJson{{ loop.index }}" rows="10" cols="80" readonly style="display:none"></textarea><br>
     <button id="copyJson{{ loop.index }}" onclick="copyJson({{ loop.index }})" style="display:none">Copy JSON</button>
     <button id="downloadJson{{ loop.index }}" onclick="downloadJson({{ loop.index }})" style="display:none">Download JSON</button>
     <button id="prettyJson{{ loop.index }}" onclick="prettyPrint({{ loop.index }})" style="display:none">Pretty Print JSON</button>


### PR DESCRIPTION
## Summary
- support a new `bdr_json` column in the DB
- keep BDR extraction results separate from arrival/departure JSON
- show a dedicated BDR JSON field in the admin interface
- populate the new field from the frontend
- expose an extra textarea on the results page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854f5bf1820832d827c47ec00bee87e