### PR TITLE
Support two-step BDR extraction

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -20,7 +20,8 @@ def init_db(path: str = DB_PATH):
                 prompt TEXT,
                 output TEXT,
                 json TEXT,
-                bdr_json TEXT
+                bdr_json TEXT,
+                bdr_md TEXT
             )"""
         )
         # Upgrade schema if ``json`` column is missing (for databases created
@@ -30,6 +31,8 @@ def init_db(path: str = DB_PATH):
             conn.execute("ALTER TABLE requests ADD COLUMN json TEXT")
         if "bdr_json" not in cols:
             conn.execute("ALTER TABLE requests ADD COLUMN bdr_json TEXT")
+        if "bdr_md" not in cols:
+            conn.execute("ALTER TABLE requests ADD COLUMN bdr_md TEXT")
         # Table for storing per-job metadata such as the job name
         conn.execute(
             "CREATE TABLE IF NOT EXISTS jobmeta (name TEXT)"
@@ -55,11 +58,12 @@ def log_request(
     db_path: str = DB_PATH,
     json_text: str = "",
     bdr_json_text: str = "",
+    bdr_md_text: str = "",
 ):
     """Insert a request row into the database at ``db_path``."""
     with get_db(db_path) as conn:
         conn.execute(
-            "INSERT INTO requests (filename, timestamp, ip, prompt, output, json, bdr_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO requests (filename, timestamp, ip, prompt, output, json, bdr_json, bdr_md) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 filename,
                 datetime.datetime.utcnow().isoformat(),
@@ -68,6 +72,7 @@ def log_request(
                 output,
                 json_text,
                 bdr_json_text,
+                bdr_md_text,
             ),
         )
 

--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -45,11 +45,16 @@
         <label>JSON:<br>
             <textarea name="json_{{ r.id }}" rows="10" cols="80">{{ r.json }}</textarea>
         </label>
+        <label>BDR Tables:<br>
+            <textarea name="bdr_md_{{ r.id }}" rows="10" cols="80">{{ r.bdr_md }}</textarea>
+        </label>
+        <div id="bdr-html-{{ r.id }}"></div>
         <label>BDR JSON:<br>
             <textarea name="bdr_json_{{ r.id }}" rows="10" cols="80">{{ r.bdr_json }}</textarea>
         </label>
         <button type="button" data-json-id="{{ r.id }}" onclick="adminGenerateJSON({{ r.id }})">Generate JSON</button>
-        <button type="button" onclick="extractBDR({{ r.id }})">Extract BDR</button>
+        <button type="button" onclick="extractBDR({{ r.id }})">Extract BDR Tables</button>
+        <button type="button" onclick="bdrTablesToJSON({{ r.id }})">BDR Tables → JSON</button>
         <button type="button" onclick="prettyPrintTextarea('json_{{ r.id }}')">Pretty Print JSON</button>
         <button type="button" onclick="prettyPrintTextarea('bdr_json_{{ r.id }}')">Pretty Print BDR JSON</button>
         <button type="button" onclick="openJSONEditor({{ r.id }})">Edit JSON</button>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -399,9 +399,38 @@ function extractBDR(id){
         alert(data.error);
         return;
       }
+      const txt = document.querySelector(`textarea[name='bdr_md_${id}']`);
+      if (txt) txt.value = data.bdr_md;
+      const htmlContainer = document.querySelector(`#bdr-html-${id}`);
+      if (htmlContainer) htmlContainer.innerHTML = data.html;
+      showStatus('BDR tables extracted');
+    })
+    .finally(() => {
+      stopProgress();
+    });
+}
+
+function bdrTablesToJSON(id){
+  startProgress();
+  const jobId = document.body.dataset.jobId;
+  const md = document.querySelector(`textarea[name='bdr_md_${id}']`).value;
+  fetch(`/bdr_json/${jobId}/${id}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCSRFToken()
+    },
+    body: JSON.stringify({markdown: md})
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (data.error){
+        alert(data.error);
+        return;
+      }
       const txt = document.querySelector(`textarea[name='bdr_json_${id}']`);
       if (txt) txt.value = data.bdr_json;
-      showStatus('BDR data extracted');
+      showStatus('BDR JSON generated');
     })
     .finally(() => {
       stopProgress();

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -96,6 +96,8 @@ def test_job_detail_upgrades_schema(client, tmp_path):
     with sqlite3.connect(db_path) as conn_check:
         cols = [r[1] for r in conn_check.execute('PRAGMA table_info(requests)')]
     assert 'json' in cols
+    assert 'bdr_json' in cols
+    assert 'bdr_md' in cols
 
 
 def test_delete_job(client, tmp_path):


### PR DESCRIPTION
## Summary
- extract BDR information as markdown tables first
- convert BDR tables to JSON with a new route
- store BDR markdown in the database
- expose new BDR buttons in the admin UI
- update tests for new schema

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855d30d9524832da7422dc87bc9c6de