### PR TITLE
Fix BDR extraction using wrong job id

### DIFF
--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -53,8 +53,8 @@
             <textarea name="bdr_json_{{ r.id }}" rows="10" cols="80">{{ r.bdr_json }}</textarea>
         </label>
         <button type="button" data-json-id="{{ r.id }}" onclick="adminGenerateJSON({{ r.id }})">Generate JSON</button>
-        <button type="button" onclick="extractBDR({{ r.id }})">Extract BDR Tables</button>
-        <button type="button" onclick="bdrTablesToJSON({{ r.id }})">BDR Tables → JSON</button>
+        <button type="button" onclick="extractBDR('{{ job_id }}', {{ r.id }})">Extract BDR Tables</button>
+        <button type="button" onclick="bdrTablesToJSON('{{ job_id }}', {{ r.id }})">BDR Tables → JSON</button>
         <button type="button" onclick="prettyPrintTextarea('json_{{ r.id }}')">Pretty Print JSON</button>
         <button type="button" onclick="prettyPrintTextarea('bdr_json_{{ r.id }}')">Pretty Print BDR JSON</button>
         <button type="button" onclick="openJSONEditor({{ r.id }})">Edit JSON</button>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -384,9 +384,8 @@ function adminGenerateJSON(id){
     });
 }
 
-function extractBDR(id){
+function extractBDR(jobId, id){
   startProgress();
-  const jobId = document.body.dataset.jobId;
   fetch(`/extract_bdr/${jobId}/${id}`, {
     method: 'POST',
     headers: {
@@ -410,9 +409,8 @@ function extractBDR(id){
     });
 }
 
-function bdrTablesToJSON(id){
+function bdrTablesToJSON(jobId, id){
   startProgress();
-  const jobId = document.body.dataset.jobId;
   const md = document.querySelector(`textarea[name='bdr_md_${id}']`).value;
   fetch(`/bdr_json/${jobId}/${id}`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- pass the current job id explicitly when extracting BDR data
- update front-end JavaScript accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855d5eb6124832d85959397350a7fc8