### PR TITLE
Improve frontend styling

### DIFF
--- a/frontend/error.html
+++ b/frontend/error.html
@@ -2,11 +2,14 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Error</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+<div class="container">
     <h2>{{ message }}</h2>
     <a href="{{ url_for('history') }}">Back</a>
+</div>
 </body>
 </html>

--- a/frontend/history.html
+++ b/frontend/history.html
@@ -2,10 +2,12 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Job History</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+<div class="container">
     <h2>Job History</h2>
     <a href="{{ url_for('upload') }}">Back</a>
     <table>
@@ -25,6 +27,7 @@
             <td>{{ job.ip }}</td>
         </tr>
         {% endfor %}
-    </table>
+</table>
+</div>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Login</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>

--- a/frontend/job_detail.html
+++ b/frontend/job_detail.html
@@ -2,12 +2,14 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Edit Job {{ job_id }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsoneditor@9.10.0/dist/jsoneditor.min.css">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body data-job-id="{{ job_id }}">
+<div class="container">
     <div id="progress-container" style="display:none">
         <div id="progress-bar"></div>
     </div>
@@ -72,5 +74,6 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/jsoneditor@9.10.0/dist/jsoneditor.min.js"></script>
     <script src="{{ url_for('static', filename='main.js') }}"></script>
+</div>
 </body>
 </html>

--- a/frontend/result.html
+++ b/frontend/result.html
@@ -2,11 +2,13 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Results</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
+<div class="container">
     <div id="progress-container" style="display:none">
         <div id="progress-bar"></div>
     </div>
@@ -35,6 +37,7 @@
     </form>
     <hr>
     {% endfor %}
+</div>
 <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,9 +1,56 @@
-body { font-family: Arial, sans-serif; margin:40px; }
-#drop-area { border:2px dashed #ccc; padding:20px; }
-.thumb { width:100px; margin:5px; }
-pre { background:#f2f2f2; padding:10px; }
-table { border-collapse:collapse; margin-bottom:20px; }
-th, td { border:1px solid #ccc; padding:4px 8px; }
+# @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+  --primary: #2563eb;
+  --bg: #f8f9fc;
+  --text: #1f2937;
+  --border: #e5e7eb;
+}
+
+body {
+  font-family: 'Inter', Arial, sans-serif;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 20px;
+}
+#drop-area {
+  border: 2px dashed var(--border);
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+  margin-bottom: 20px;
+  background: #fff;
+}
+
+.thumb {
+  width: 100px;
+  margin: 5px;
+  border-radius: 4px;
+}
+
+pre {
+  background: #f2f2f2;
+  padding: 10px;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+
+th, td {
+  border: 1px solid var(--border);
+  padding: 8px;
+}
 table.editable input {
   width:100%;
   border:none;
@@ -13,32 +60,127 @@ table.editable input {
 table.editable input:focus {
   outline:2px solid #4caf50;
 }
+
 .edit-note { font-style: italic; color: #555; margin: 5px 0; }
-form.login { display:flex; flex-direction:column; align-items:center; background:#fff; padding:20px; border-radius:5px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
-body.login-page { display:flex; justify-content:center; align-items:center; height:100vh; background:#f2f2f2; }
 
-.preview { display:inline-block; text-align:center; margin:5px; }
-.modal { display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.8); justify-content:center; align-items:center; z-index:1000; }
-.modal-content { background:#fff; padding:20px; max-width:90%; max-height:90%; overflow:auto; }
-#editor-image { max-width:100%; height:auto; }
-.controls { margin-top:10px; display:flex; flex-wrap:wrap; gap:5px; align-items:center; }
-.controls button { padding:4px 8px; }
-
-#json-preview {
-  background:#f2f2f2;
-  padding:10px;
-  white-space:pre-wrap;
-  margin-top:10px;
+form.login {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
-#progress-container { position:fixed; top:0; left:0; width:100%; height:4px; background:#eee; z-index:9999; }
-#progress-bar { width:0%; height:100%; background:#4caf50; transition:width 0.3s ease; }
+body.login-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: var(--bg);
+}
+
+button,
+input[type="submit"] {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover,
+input[type="submit"]:hover {
+  background: #1e40af;
+}
+
+input[type="text"],
+input[type="password"],
+textarea {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.preview {
+  display: inline-block;
+  text-align: center;
+  margin: 5px;
+}
+#modal {
+  display: none;
+}
+
+.modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  max-width: 90%;
+  max-height: 90%;
+  overflow: auto;
+  border-radius: 8px;
+}
+#editor-image {
+  max-width: 100%;
+  height: auto;
+}
+
+.controls {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  align-items: center;
+}
+
+.controls button {
+  padding: 4px 8px;
+}
+
+#json-preview {
+  background: #f2f2f2;
+  padding: 10px;
+  white-space: pre-wrap;
+  margin-top: 10px;
+}
+
+#progress-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: #eee;
+  z-index: 9999;
+}
+
+#progress-bar {
+  width: 0%;
+  height: 100%;
+  background: #4caf50;
+  transition: width 0.3s ease;
+}
 
 #status-message {
-  background:#ddf0d8;
-  border:1px solid #a6d3a0;
-  color:#333;
-  padding:8px 12px;
-  margin-bottom:10px;
-  display:none;
+  background: #ddf0d8;
+  border: 1px solid #a6d3a0;
+  color: #333;
+  padding: 8px 12px;
+  margin-bottom: 10px;
+  display: none;
 }

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -2,10 +2,12 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Upload</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+<div class="container">
     <h2>Upload Images (Model: {{ model }})</h2>
     <a href="{{ url_for('history') }}">Admin</a> |
     <a href="{{ url_for('logout') }}">Logout</a>
@@ -41,6 +43,7 @@
     {% with messages = get_flashed_messages() %}
       {% if messages %}<div>{{ messages[0] }}</div>{% endif %}
     {% endwith %}
+</div>
 <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize the look and feel of the frontend
- apply Inter font and color variables
- wrap content in responsive container blocks
- add viewport meta tags to all pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855de765168832d840a6dec6c3c7ca2