### PR TITLE
Fix missing rate limit on BDR API endpoints

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -358,6 +358,7 @@ def update_json(job_id, req_id):
 
 
 @app.route('/extract_bdr/<job_id>/<int:req_id>', methods=['POST'])
+@limiter.limit(f"{RATE_LIMIT_PER_HOUR}/hour")
 def extract_bdr_route(job_id, req_id):
     """Extract BDR tables from the original image and store the markdown."""
     if not session.get('logged_in'):
@@ -405,6 +406,7 @@ def extract_bdr_route(job_id, req_id):
 
 
 @app.route('/bdr_json/<job_id>/<int:req_id>', methods=['POST'])
+@limiter.limit(f"{RATE_LIMIT_PER_HOUR}/hour")
 def bdr_json_route(job_id, req_id):
     """Convert stored BDR tables to JSON and save the result."""
     if not session.get('logged_in'):


### PR DESCRIPTION
## Summary
- protect `/extract_bdr` and `/bdr_json` endpoints with the same hourly rate limit as other routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68801ab9d670832da414edcdfc9d8655